### PR TITLE
Fixed logic about how mailto links are handled

### DIFF
--- a/src/scribe-plugin-link-prompt-command.js
+++ b/src/scribe-plugin-link-prompt-command.js
@@ -32,11 +32,12 @@ define(function () {
 
         if (link) {
           // Prepend href protocol if missing
-          // For emails we just look for a `@` symbol as it is easier.
+          // If a http/s or mailto link is provided, then we will trust that an link is valid
           var urlProtocolRegExp = /^https?\:\/\//;
-          // We don't want to match URLs that sort of look like email addresses
-          if (! urlProtocolRegExp.test(link)) {
-            if (! /^mailto\:/.test(link) && /@/.test(link)) {
+          var mailtoProtocolRegExp = /^mailto\:/;
+          if (! urlProtocolRegExp.test(link) && ! mailtoProtocolRegExp.test(link)) {
+            // For emails we just look for a `@` symbol as it is easier.
+            if (/@/.test(link)) {
               var shouldPrefixEmail = window.confirm(
                 'The URL you entered appears to be an email address. ' +
                 'Do you want to add the required “mailto:” prefix?'


### PR DESCRIPTION
If someone enters and http/s: or mailto: link, then I think we should trust the link as acceptable.
If not, then it makes sense to prompt them to fix the url by adding either mailto: or http:// to the start of the input data.
However, before this fix, if someone enters "mailto:test@test.com" they are prompted whether they are sure if they want to add "http://" to the start of the link.