### PR TITLE
Add an optional parameter to set the link with

### DIFF
--- a/src/scribe-plugin-link-prompt-command.js
+++ b/src/scribe-plugin-link-prompt-command.js
@@ -10,16 +10,24 @@ define(function () {
     return function (scribe) {
       var linkPromptCommand = new scribe.api.Command('createLink');
 
+
       linkPromptCommand.nodeName = 'A';
 
-      linkPromptCommand.execute = function () {
+      linkPromptCommand.execute = function (passedLink) {
+        var link;
         var selection = new scribe.api.Selection();
         var range = selection.range;
         var anchorNode = selection.getContaining(function (node) {
           return node.nodeName === this.nodeName;
         }.bind(this));
+
         var initialLink = anchorNode ? anchorNode.href : '';
-        var link = window.prompt('Enter a link.', initialLink);
+
+        if (!passedLink)  {
+          link = window.prompt('Enter a link.', initialLink);
+        } else {
+          link = passedLink;
+        }
 
         if (anchorNode) {
           range.selectNode(anchorNode);


### PR DESCRIPTION
This adds an optional argument to the execute function so that we can pass an existing item in to link to. It is useful is you just want to execute the command without having to use the link box, which is pretty annoying at times. It will make it possible to select text and embed it in composer.