### PR TITLE
Protocol checking: modularistion and example page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.1
+
+The plugin now checks whether there are any non-whitespace characters in the supplied link.
+
 # 0.3.0
 
 The plugin will now accept an optional validation rule that allows proposed links to be vetoed. See the README for more information.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Run unit tests with the following:
 npm run test
 ```
 
+### Running locally
+
+First run `bower install` to add the dependencies locally. Then load `examples/amd.html` into a browser and you should have a minimal local running version of the plugin.
+
 ## Installation
 
 ```

--- a/bower.json
+++ b/bower.json
@@ -1,3 +1,8 @@
 {
-  "name": "scribe-plugin-link-prompt-command"
+  "name": "scribe-plugin-link-prompt-command",
+  "devDependencies": {
+    "requirejs": "~2.1.9",
+    "scribe": "guardian/scribe#master",
+    "scribe-plugin-toolbar": "guardian/scribe-plugin-toolbar#master"
+  }
 }

--- a/example/amd.html
+++ b/example/amd.html
@@ -1,0 +1,79 @@
+<!--
+This example demonstrates how to consume the Scribe
+editor using RequireJS and the AMD module syntax.
+
+Note that you'll need to install scribe's dependencies through
+`bower install`. See http://bower.io/ if you are unfamiliar.
+-->
+<style>
+  button {
+    height: 3em;
+  }
+
+  .active {
+    border-style: inset;
+  }
+
+  .rte, .rte-toolbar {
+    display: block;
+  }
+
+  p {
+    margin-top: 0;
+  }
+
+  .rte {
+    border: 1px solid gray;
+    height: 300px;
+    overflow: auto;
+  }
+  .rte-output {
+    width: 100%;
+    height: 10em;
+  }
+</style>
+<script src="../bower_components/requirejs/require.js"></script>
+<script>
+require({
+  paths: {
+    'lodash-amd': '../bower_components/lodash-amd',
+    'immutable': '../bower_components/immutable/dist/immutable',
+    'scribe': '../bower_components/scribe/src',
+    'scribeToolbar': '../bower_components/scribe-plugin-toolbar/src/scribe-plugin-toolbar',
+  }
+}, [
+  'scribe/scribe',
+  '../src/scribe-plugin-link-prompt-command',
+  'scribeToolbar'
+], function (
+  Scribe,
+  linkPlugin,
+  scribePluginToolbar
+) {
+  var scribe = new Scribe(document.querySelector('.rte'));
+  window.scribe = scribe;
+
+  scribe.setContent('<p>Hello, World!<\/p>');
+
+  scribe.use(scribePluginToolbar(document.querySelector('.rte-toolbar')));
+  scribe.use(linkPlugin());
+
+  scribe.on('content-changed', updateHtml);
+
+  function updateHtml() {
+    document.querySelector('.rte-output').value = scribe.getHTML();
+  }
+
+  updateHtml();
+});
+</script>
+
+<div class="rte-toolbar">
+  <button data-command-name="linkPrompt">Link</button>
+</div>
+
+<div class="rte"></div>
+<section>
+  <h1>Output</h1>
+  <textarea class="rte-output" readonly></textarea>
+</section>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scribe-plugin-link-prompt-command",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "src/scribe-plugin-link-prompt-command.js",
   "dependencies": {
    },

--- a/src/checks.js
+++ b/src/checks.js
@@ -2,11 +2,23 @@ define([], function () {
 
   'use strict';
 
+  var urlProtocolRegExp = /^https?\:\/\//;
+  var mailtoProtocolRegExp = /^mailto\:/;
+  var telProtocolRegExp = /^tel\:/;
+
+  var knownProtocols = [urlProtocolRegExp, mailtoProtocolRegExp, telProtocolRegExp];
+
   function emptyLink(string) {
     return /\w/.test(string);
   }
 
+  function hasKnownProtocol(urlValue) {
+    // If a http/s or mailto link is provided, then we will trust that an link is valid
+    return knownProtocols.some(function(protocol) { return protocol.test(urlValue)});
+  }
+
   return {
-    emptyLink: emptyLink
+    emptyLink: emptyLink,
+    hasKnownProtocol: hasKnownProtocol
   };
 });

--- a/src/scribe-plugin-link-prompt-command.js
+++ b/src/scribe-plugin-link-prompt-command.js
@@ -56,10 +56,7 @@ define(['./checks'], function (checks) {
 
         if (link) {
           // Prepend href protocol if missing
-          // If a http/s or mailto link is provided, then we will trust that an link is valid
-          var urlProtocolRegExp = /^https?\:\/\//;
-          var mailtoProtocolRegExp = /^mailto\:/;
-          var telProtocolRegExp = /^tel\:/;
+
           if (! urlProtocolRegExp.test(link) && ! mailtoProtocolRegExp.test(link) && ! telProtocolRegExp.test(link) ) {
             // For emails we just look for a `@` symbol as it is easier.
             // For tel numbers check for + and numerical values

--- a/src/scribe-plugin-link-prompt-command.js
+++ b/src/scribe-plugin-link-prompt-command.js
@@ -71,13 +71,13 @@ define(['./checks'], function (checks) {
               if (shouldPrefixEmail) {
                 link = 'mailto:' + link;
               }
-            } else if (/+/.test(link) || isNaN(link) ) {
+            } else if (/\+\d+/.test(link)) {
               var shouldPrefixTel = window.confirm(
                 'The URL you entered appears to be a telephone number.' +
                 'Do you want to add the required “tel:” prefix?'
               );
-              if (shouldPrefixTel) { 
-                link = 'tel:' + link; 
+              if (shouldPrefixTel) {
+                link = 'tel:' + link;
               }
             } else {
               var shouldPrefixLink = window.confirm(

--- a/src/scribe-plugin-link-prompt-command.js
+++ b/src/scribe-plugin-link-prompt-command.js
@@ -55,9 +55,8 @@ define(['./checks'], function (checks) {
         // to compose?
 
         if (link) {
-          // Prepend href protocol if missing
 
-          if (! urlProtocolRegExp.test(link) && ! mailtoProtocolRegExp.test(link) && ! telProtocolRegExp.test(link) ) {
+          if (! checks.hasKnownProtocol(link) ) {
             // For emails we just look for a `@` symbol as it is easier.
             // For tel numbers check for + and numerical values
             if (/@/.test(link)) {
@@ -70,7 +69,7 @@ define(['./checks'], function (checks) {
               }
             } else if (/\+\d+/.test(link)) {
               var shouldPrefixTel = window.confirm(
-                'The URL you entered appears to be a telephone number.' +
+                'The URL you entered appears to be a telephone number. ' +
                 'Do you want to add the required “tel:” prefix?'
               );
               if (shouldPrefixTel) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -35,4 +35,26 @@ describe('Checks', function() {
       });
     });
   });
+
+  describe('protocols', function() {
+    it('should recognise http as known', function() {
+      assert.isTrue(checks.hasKnownProtocol('http://www.example.com'));
+    });
+
+    it('should recognise https as known', function() {
+      assert.isTrue(checks.hasKnownProtocol('https://www.example.com'));
+    });
+
+    it('should recognise mailto as known', function() {
+      assert.isTrue(checks.hasKnownProtocol('mailto:user@example.com'));
+    });
+
+    it('should recognise tel as known', function() {
+      assert.isTrue(checks.hasKnownProtocol('tel:+447563234567'));
+    });
+
+    it('should not recognise ftp as known', function() {
+      assert.isFalse(checks.hasKnownProtocol('ftp://ftp.example.com'));
+    })
+  });
 });


### PR DESCRIPTION
I've pulled out the protocol check into the `checks` module and added some unit tests around it.
I've also created a local example page that allows people to play around with the plugin locally.