### PR TITLE
Transformations: add transformation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ The `validation` key can be given a function that takes a string representing a 
   }
 ```
 
+### Transformation
+
+The `transformation` key holds two optional keys: `pre` and `post`. Each one contains an array of transform functions that take a String representing the link value and should return a String that is transformed value of the link.
+
+The transformations are processed "left to right" or in ascending index order.
+
+`pre` transforms are applied before validation. `post` transforms are applied just before the link value is inserted into the DOM.
+
 ## Testing
 
 Run unit tests with the following:

--- a/src/init.js
+++ b/src/init.js
@@ -1,0 +1,22 @@
+define([], function () {
+
+  function init(options) {
+    var options = options || {};
+
+    if(!options.transforms) {
+      options.transforms = {};
+    }
+
+    ['pre', 'post'].forEach(function(key) {
+      if(!options.transforms[key]) {
+        options.transforms[key] = [];
+      }
+    });
+
+    return options;
+  }
+
+  return {
+    init: init
+  }
+});

--- a/src/scribe-plugin-link-prompt-command.js
+++ b/src/scribe-plugin-link-prompt-command.js
@@ -1,5 +1,7 @@
 
-define(['./checks'], function (checks) {
+define(['./checks',
+  './init',
+  './transforms'], function (checks, init, transforms) {
 
   /**
    * This plugin adds a command for creating links, including a basic prompt.
@@ -8,7 +10,7 @@ define(['./checks'], function (checks) {
   'use strict';
 
   return function (options) {
-    var options = options || {};
+    var options = init.init(options);
 
     return function (scribe) {
       var linkPromptCommand = new scribe.api.Command('createLink');
@@ -30,6 +32,8 @@ define(['./checks'], function (checks) {
         } else {
           link = passedLink;
         }
+
+        link = transforms.run(options.transforms.pre, link);
 
         if(!checks.emptyLink(link)) {
           window.alert('This link appears empty');
@@ -85,6 +89,8 @@ define(['./checks'], function (checks) {
               }
             }
           }
+
+          link = transforms.run(options.transforms.post, link);
 
           scribe.api.SimpleCommand.prototype.execute.call(this, link);
         }

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -1,0 +1,13 @@
+define([], function () {
+
+
+  function run(transforms, initialLink) {
+    return transforms.reduce(function(currentLinkValue, transform) {
+      return transform(currentLinkValue);
+      }, initialLink);
+  }
+
+  return {
+    run: run
+  }
+});

--- a/test/init.js
+++ b/test/init.js
@@ -1,0 +1,66 @@
+var assert = require("chai").assert;
+
+require('node-amd-require')({
+  baseUrl: __dirname
+});
+
+var init = require('../src/init.js');
+
+describe('Init', function() {
+
+  describe('with no options supplied', function() {
+    it('should initialise the options', function() {
+
+      var result = init.init();
+      var expected = {
+        transforms: {
+          pre: [],
+          post: []
+        }
+      };
+
+      assert.deepEqual(result, expected);
+    });
+  });
+
+  describe('with all options supplied', function() {
+    it('should respect the users options', function() {
+      var myOptions = {
+        validation: function(link) { return true; },
+        transforms: {
+          pre: [function(link) { return "http://www.theguardian.com"}],
+          post: [function(link) { return link; }]
+        }
+      };
+
+      assert.deepEqual(init.init(myOptions), myOptions);
+    });
+  });
+
+    describe('with some options supplied', function() {
+    it('should respect the users options', function() {
+      var exampleFunction = function(link) { return link; };
+
+      var myOptions = {
+         transforms: {
+          post: [exampleFunction]
+        }
+      };
+      var expected = {
+         transforms: {
+          pre: [],
+          post: [exampleFunction]
+        }
+      };
+
+      var result = init.init(myOptions);
+      assert.property(result, 'transforms');
+      // We don't care about the order the attributes occur in
+      assert.property(result.transforms, 'pre');
+      assert.property(result.transforms, 'post');
+
+      assert.sameMembers(result.transforms.pre, expected.transforms.pre);
+      assert.sameMembers(result.transforms.post, expected.transforms.post);
+    });
+  });
+});

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -1,0 +1,43 @@
+var assert = require("chai").assert;
+
+require('node-amd-require')({
+  baseUrl: __dirname
+});
+
+var transforms = require('../src/transforms.js');
+
+describe('Transforms', function() {
+  var link = 'http://www.guardian.co.uk';
+
+  beforeEach(function() {
+    link = 'http://www.guardian.co.uk';
+  });
+
+  describe('with no transforms', function() {
+    it('should return the link unchanged', function() {
+
+      var result = transforms.run([], link);
+      assert.equal(result, link);
+    });
+  });
+
+  describe('with a transform', function() {
+    it('should apply the transform', function() {
+      var transform = function(link) { return link.replace('guardian.co.uk', "theguardian.com")};
+      var result = transforms.run([transform], link);
+
+      assert.equal(result, 'http://www.theguardian.com');
+    });
+  });
+
+  describe('with multiple transforms', function() {
+    it('transforms should be applied in order', function() {
+      var a = function(link) { return link.replace('guardian.co.uk', "theguardian.com")};
+      var b = function(link) { return link.replace('theguardian', 'thegarden')};
+
+      var result = transforms.run([a, b], link);
+
+      assert.equal(result, 'http://www.thegarden.com');
+    });
+  });
+});


### PR DESCRIPTION
This change allows the plugin to manipulate the value of the link the plugin operates on.
This will allow automatic translation of old domains (guardian.co.uk) into new ones (theguardian.com).