### PR TITLE
Fix regexp for tel numbers

### DIFF
--- a/src/prompts.js
+++ b/src/prompts.js
@@ -12,7 +12,7 @@ define([], function() {
     },
     {
       // For tel numbers check for + and numerical values
-      regexp: /\+?\d+/,
+      regexp: /^\+?\d+$/,
       message: 'The URL you entered appears to be a telephone number. ' +
                 'Do you want to add the required “tel:” prefix?',
       action: function(link) {

--- a/test/prompts.js
+++ b/test/prompts.js
@@ -18,8 +18,10 @@ describe('Generic links', function() {
 
   describe('add http protocol', function() {
     it('if user agrees', function() {
-      var result = prompts.process(fakeAgreeableWindow, 'www.example.com');
-      assert.equal(result, 'http://www.example.com');
+      ['www.example.com', 'www.example.com/posts/12345678'].forEach(function(exampleUrl) {
+        var result = prompts.process(fakeAgreeableWindow, exampleUrl);
+        assert.equal(result, 'http://' + exampleUrl);
+      });
     });
 
     it('but not if the user disagrees', function() {


### PR DESCRIPTION
Before this fix, if we input "example.com/page/123" we will get "tel:example.com/page/123"
Need to add a ^ and $ to determine the start and end of the input.
